### PR TITLE
Fix sprite read error in 1.1.39 

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -292,7 +292,7 @@ turn_to_tank =
         {
           priority = "low",
           width = 104,
-          height = 84,
+          height = 64,
           frame_count = 2,
           apply_runtime_tint = true,
           direction_count = 64,


### PR DESCRIPTION
MOD読み込みエラー
MOD The given sprite rectangle (left_top=0x1764, right_bottom=104x1848) is outside the actual sprite size (left_top=0x0, right_bottom=104x1826). See the log file for more information; .base_/ graphics/entity/tank/tank-base-mask-1.png」の読み込みに失敗しました」

This error fixed in this pull req.

![Error](https://user-images.githubusercontent.com/32031701/133208397-4c8c5310-3110-4369-bc94-5aab7b1f5361.png)
